### PR TITLE
get rid of sed

### DIFF
--- a/check_vcenter_health.sh
+++ b/check_vcenter_health.sh
@@ -13,11 +13,11 @@ UNK=grey
 HOSTADDRESS=$1
 PASSWD=$2
 SERVICE=$3
-SESSIONID=`curl -ksX POST -H "Authorization: Basic ${PASSWD}" -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-use-header-authn: test" -H "vmware-api-session-id: null" "https://${HOSTADDRESS}/rest/com/vmware/cis/session" | jq .[] | sed 's/"//g'`
+SESSIONID=`curl -ksX POST -H "Authorization: Basic ${PASSWD}" -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-use-header-authn: test" -H "vmware-api-session-id: null" "https://${HOSTADDRESS}/rest/com/vmware/cis/session" | jq -r .[]`
 
 case $SERVICE in
   load|mem|storage|swap)
-    HEALTH=`curl -ksX GET -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" "https://${HOSTADDRESS}/rest/appliance/health/${SERVICE}" | jq .[] | sed 's/"//g'`
+    HEALTH=`curl -ksX GET -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" "https://${HOSTADDRESS}/rest/appliance/health/${SERVICE}" | jq -r .[]`
     MESSAGE=`curl -ksX GET -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" "https://${HOSTADDRESS}/rest/appliance/health/${SERVICE}/messages" | jq .[]`
     if [ "$HEALTH" == "$OK" ]; then
       echo "$SERVICE is $HEALTH"
@@ -42,7 +42,7 @@ case $SERVICE in
     fi
     ;;
   applmgmt|database-storage|software-packages|system)
-    HEALTH=`curl -ksX GET -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" "https://${HOSTADDRESS}/rest/appliance/health/${SERVICE}" | jq .[] | sed 's/"//g'`
+    HEALTH=`curl -ksX GET -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" "https://${HOSTADDRESS}/rest/appliance/health/${SERVICE}" | jq -r .[]`
     if [ "$HEALTH" == "$OK" ]; then
       echo "$SERVICE is $HEALTH"
       exit 0
@@ -63,8 +63,8 @@ case $SERVICE in
   vcha)
     OK_MODE=ENABLED
     OK_HEALTH=HEALTHY
-    MODE=`curl -ksX POST -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" -d '{ "partial": true }' "https://${HOSTADDRESS}/rest/vcenter/vcha/cluster?action=get" | jq '.[] | .mode' | sed 's/"//g'`
-    HEALTH=`curl -ksX POST -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" -d '{ "partial": true }' "https://${HOSTADDRESS}/rest/vcenter/vcha/cluster?action=get" | jq '.[] | .health_state' | sed 's/"//g'`
+    MODE=`curl -ksX POST -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" -d '{ "partial": true }' "https://${HOSTADDRESS}/rest/vcenter/vcha/cluster?action=get" | jq -r '.[] | .mode'`
+    HEALTH=`curl -ksX POST -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" -d '{ "partial": true }' "https://${HOSTADDRESS}/rest/vcenter/vcha/cluster?action=get" | jq -r '.[] | .health_state'`
     if [ $MODE == $OK_MODE ] && [ $HEALTH == $OK_HEALTH ]; then
       echo mode:$MODE health_state:$HEALTH
       exit 0


### PR DESCRIPTION
It's unnecessary to spawn _sed(1)_ multiple times in the script just to strip
the quotes. The `-r` (`--raw-output`) option to _jq(1)_ can be used instead. It
makes the script slightly faster and less CPU intensive.