### PR TITLE
Netrc

### DIFF
--- a/check_vcenter_health.sh
+++ b/check_vcenter_health.sh
@@ -11,9 +11,8 @@ CRIT=red
 UNK=grey
 
 HOSTADDRESS=$1
-PASSWD=$2
-SERVICE=$3
-SESSIONID=`curl -ksX POST -H "Authorization: Basic ${PASSWD}" -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-use-header-authn: test" -H "vmware-api-session-id: null" "https://${HOSTADDRESS}/rest/com/vmware/cis/session" | jq -r .[]`
+SERVICE=$2
+SESSIONID=`curl -n -ksX POST -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-use-header-authn: test" -H "vmware-api-session-id: null" "https://${HOSTADDRESS}/rest/com/vmware/cis/session" | jq -r .[]`
 
 case $SERVICE in
   load|mem|storage|swap)

--- a/check_vcenter_health.sh
+++ b/check_vcenter_health.sh
@@ -13,11 +13,11 @@ UNK=grey
 HOSTADDRESS=$1
 PASSWD=$2
 SERVICE=$3
-SESSIONID=`curl -ksX POST -H "Authorization: Basic ${PASSWD}" -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-use-header-authn: test" -H "vmware-api-session-id: null" "https://${HOSTADDRESS}/rest/com/vmware/cis/session" | jq .[] | sed 's/"//g'`
+SESSIONID=`curl -ksX POST -H "Authorization: Basic ${PASSWD}" -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-use-header-authn: test" -H "vmware-api-session-id: null" "https://${HOSTADDRESS}/rest/com/vmware/cis/session" | jq -r .[]`
 
 case $SERVICE in
   load|mem|storage|swap)
-    HEALTH=`curl -ksX GET -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" "https://${HOSTADDRESS}/rest/appliance/health/${SERVICE}" | jq .[] | sed 's/"//g'`
+    HEALTH=`curl -ksX GET -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" "https://${HOSTADDRESS}/rest/appliance/health/${SERVICE}" | jq -r .[]`
     MESSAGE=`curl -ksX GET -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" "https://${HOSTADDRESS}/rest/appliance/health/${SERVICE}/messages" | jq .[]`
     if [ "$HEALTH" == "$OK" ]; then
       echo "$SERVICE is $HEALTH"
@@ -42,7 +42,7 @@ case $SERVICE in
     fi
     ;;
   applmgmt|database-storage|software-packages|system)
-    HEALTH=`curl -ksX GET -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" "https://${HOSTADDRESS}/rest/appliance/health/${SERVICE}" | jq .[] | sed 's/"//g'`
+    HEALTH=`curl -ksX GET -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" "https://${HOSTADDRESS}/rest/appliance/health/${SERVICE}" | jq -r .[]`
     if [ "$HEALTH" == "$OK" ]; then
       echo "$SERVICE is $HEALTH"
       exit 0
@@ -63,8 +63,8 @@ case $SERVICE in
   vcha)
     OK_MODE=ENABLED
     OK_HEALTH=HEALTHY
-    MODE=`curl -ksX POST -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" -d '{ "partial": true }' "https://${HOSTADDRESS}/rest/vcenter/vcha/cluster?action=get" | jq '.[] | .mode' | sed 's/"//g'`
-    HEALTH=`curl -ksX POST -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" -d '{ "partial": true }' "https://${HOSTADDRESS}/rest/vcenter/vcha/cluster?action=get" | jq '.[] | .health_state' | sed 's/"//g'`
+    MODE=`curl -ksX POST -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" -d '{ "partial": true }' "https://${HOSTADDRESS}/rest/vcenter/vcha/cluster?action=get" | jq -r '.[] | .mode'`
+    HEALTH=`curl -ksX POST -H "Content-Type: application/json" -H "Accept: application/json" -H "vmware-api-session-id: ${SESSIONID}" -d '{ "partial": true }' "https://${HOSTADDRESS}/rest/vcenter/vcha/cluster?action=get" | jq -r '.[] | .health_state'`
     if [ $MODE == $OK_MODE ] && [ $HEALTH == $OK_HEALTH ]; then
       echo mode:$MODE health_state:$HEALTH
       exit 0


### PR DESCRIPTION
Passing credentials (albeit Base64-encoded) as a command-line argument poses a security risk. Anyone who can issue `ps ax` (in a loop) on the Nagios machine can obtain the the vCenter credentials when the script is run by Nagios. (Username and password can easily be decoded using `base64 -d`).
    
This PR makes _curl(1)_ fetch the credentials from _~/.netrc_. The _netrc(5)_ file can be made readable by the Nagios user only, thus limiting the risk of revealing the vCenter credentials to unauthorized users.
    
NOTE: The semantics of calling the script got changed. Instead of three arguments the script now takes only two of them:
1. host address
2. service name